### PR TITLE
Use configured calendar date format

### DIFF
--- a/js/toolbox.calendar.js
+++ b/js/toolbox.calendar.js
@@ -15,7 +15,7 @@
  * for the JavaScript code in this file.
  */
 
-let calendar_format = 'dd/mm/yy';
+let calendar_format = window.calendar_format || 'dd/mm/yy';
 
 $(function() {
 	$('#rcmfd_vacationactivefrom').datepicker( {


### PR DESCRIPTION
Regardless of the setting `toolbox_vacation_jquery_dateformat`, the date picker always used the date format `'dd/mm/yy'`, hard-coded in `js/toolbox.calendar.js`.

This PR fixes this.