### PR TITLE
Aliases: multi-domain support, bugfixes

### DIFF
--- a/config.inc.php.dist
+++ b/config.inc.php.dist
@@ -219,6 +219,10 @@ $config['toolbox_roundcube_db_persistent'] = false;
 
 // ALIASES TOOL OPTIONS
 
+// If false, single domain mode is used for aliases:
+// * only aliases matching the user's domain are shown
+// * on the settings page, the domain in each alias' address is hidden (and must not be specified by the used)
+$config['toolbox_aliases_multiple_domains'] = true;
 
 // FORWARD TOOL OPTIONS
 


### PR DESCRIPTION
Add: $config['toolbox_aliases_multiple_domains'] option - when true, allows managing aliases from any domain to the logged-in user.

Fix #14, #19 point 3, also mentioned in #24: now() is no longer passed as a string

Fix #19 point 4: more robust JS callback event handling for alias toggle buttons (alias name is encoded into event name and duplicate listeners are avoided)
