### PR TITLE
Update toolbox.php

### DIFF
--- a/toolbox.php
+++ b/toolbox.php
@@ -1624,9 +1624,9 @@ class toolbox extends rcube_plugin
         $address_table->add(['class' => 'email ' . $button_type], (isset($alias['name']) ? $alias['name'] : ''));
 
         $toggle = isset($alias['active']) && $alias['active'] !== false ? rcmail::Q($this->gettext('toolbox-disable')) : rcmail::Q($this->gettext('toolbox-enable'));
-        $enable_button = $this->rcube->output->button(['command' => 'plugin.toolbox.toggle_alias', 'type' => 'link', 'class' => $button_type, 'label' => 'toolbox.toolbox-'.$button_type, 'content' => ' ', 'title' => 'toolbox.toolbox-'.$button_type]);
         $input_active = new html_checkbox(['name' => '_aliasactive[]', 'value' => '1', 'style' => 'display: none;']);
-        $address_table->add('status', $enable_button . $input_active->show(isset($alias['active']) ? $alias['active'] : ''));
+        $enable_button = $this->rcube->output->button(['command' => 'plugin.toolbox.toggle_alias', 'type' => 'link', 'class' => $button_type, 'label' => 'toolbox.toolbox-'.$button_type, 'content' => $input_active->show(isset($alias['active']) ? $alias['active'] : ''), 'title' => 'toolbox.toolbox-'.$button_type]);
+        $address_table->add('status', $enable_button);
 
         $del_button = $this->rcube->output->button(['command' => 'plugin.toolbox.delete_alias', 'type' => 'link', 'class' => 'delete', 'label' => 'delete', 'content' => ' ', 'title' => 'delete']);
         $address_table->add('control', $del_button . $hidden_name->show());


### PR DESCRIPTION
The Enabled toggle for an alias is not being rendered correctly (I think) to allow the event to be triggered when clicking the toggle switch. The switch is not contained inside the <a> tag, it's outside the <a>. The toggle switch moves back and forth, but the `plugin.toolbox.toggle_alias` command is never fired. It looks like the `html_checkbox` is appended _after_ the `$enable_button`, not contained within it.

I think a way to correct it is this to add the `$input_active->show()` to the `content =>` of the `$enable_button`. Look at the diff to see all of the changes, but this line is key:
```
$enable_button = $this->rcube->output->button([
    'command' => 'plugin.toolbox.toggle_alias',
    'type' => 'link', 
    'class' => $button_type,
    'label' => 'toolbox.toolbox-'.$button_type,
    'content' => $input_active->show(isset($alias['active']) ? $alias['active'] : ''),
    'title' => 'toolbox.toolbox-'.$button_type
]);
```